### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 CHANGES
 *******
 
-4.2 (unreleased)
+5.0 (unreleased)
 ================
 
 - Nothing changed yet.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ CHANGES
 5.0 (unreleased)
 ================
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 4.1 (2025-06-04)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -24,7 +23,7 @@ tests_require = [
     'zope.publisher',
     'zope.security',
     'zope.session >= 5.1',
-    'zope.testrunner',
+    'zope.testrunner >= 6.4',
 ]
 
 setup(name='grokcore.message',
@@ -36,9 +35,6 @@ setup(name='grokcore.message',
       author_email='grok-dev@zope.dev',
       url='https://github.com/zopefoundation/grokcore.message',
       license='ZPL-2.1',
-      namespace_packages=['grokcore'],
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
       include_package_data=True,
       zip_safe=False,
       python_requires='>=3.9',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = '4.2.dev0'
+version = '5.0.dev0'
 
 with open(os.path.join('src', 'grokcore', 'message', 'README.rst')) as f:
     readme = f.read()

--- a/src/grokcore/__init__.py
+++ b/src/grokcore/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
